### PR TITLE
Create `mac-build.yml` workflow

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -16,7 +16,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: StandaloneOSX
-      - run: zip -r FusionHelper_Mac.zip build
+      - run: zip -r FusionHelper_Mac.app.zip build/StandaloneOSX/StandaloneOSX.app
       - uses: softprops/action-gh-release@v2
         with:
           files: FusionHelper_Mac.zip

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -9,13 +9,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: Library
-          key: Library-Fusion-Helper-StandaloneOSX
-          restore-keys: |
-            Library-Fusion-Helper-
-            Library-
       - uses: game-ci/unity-builder@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -23,6 +23,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: StandaloneOSX
+      - run: zip -r FusionHelper_Mac.zip work/Fusion-Helper/Fusion-Helper
       - uses: softprops/action-gh-release@v2
         with:
-          files: work/Fusion-Helper/Fusion-Helper
+          files: FusionHelper_Mac.zip

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: Library
           key: Library-Fusion-Helper-StandaloneOSX

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -1,0 +1,21 @@
+name: Mac Build
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: StandaloneOSX
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: build

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -16,7 +16,7 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: StandaloneOSX
-      - run: zip -r FusionHelper_Mac.zip work/Fusion-Helper/Fusion-Helper
+      - run: zip -r FusionHelper_Mac.zip build
       - uses: softprops/action-gh-release@v2
         with:
           files: FusionHelper_Mac.zip

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -25,4 +25,4 @@ jobs:
           targetPlatform: StandaloneOSX
       - uses: softprops/action-gh-release@v2
         with:
-          files: build
+          files: work/Fusion-Helper/Fusion-Helper

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -9,6 +9,13 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: Library
+          key: Library-Fusion-Helper-StandaloneOSX
+          restore-keys: |
+            Library-Fusion-Helper-
+            Library-
       - uses: game-ci/unity-builder@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}


### PR DESCRIPTION
This needs three secrets (added in repository settings) to work:

- `UNITY_LICENSE`
- `UNITY_EMAIL`
- `UNITY_PASSWORD`

Getting those is described [here](https://game.ci/docs/github/activation).

The actions used are [`game-ci/unity-builder`](https://github.com/game-ci/unity-actions) and [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release).