### PR TITLE
Tidy up Mac release asset and build workflow

### DIFF
--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -16,7 +16,11 @@ jobs:
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: StandaloneOSX
-      - run: zip -r FusionHelper_Mac.app.zip build/StandaloneOSX/StandaloneOSX.app
+      - run: |
+          cd build/StandaloneOSX
+          mv StandaloneOSX.app "Fusion Helper.app"
+          zip -r FusionHelper_Mac.zip "Fusion Helper.app"
       - uses: softprops/action-gh-release@v2
         with:
-          files: FusionHelper_Mac.app.zip
+          files: build/StandaloneOSX/FusionHelper_Mac.zip
+          fail_on_unmatched_files: true

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -9,18 +9,21 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: game-ci/unity-builder@v4
+      - name: Build
+        uses: game-ci/unity-builder@v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
           targetPlatform: StandaloneOSX
-      - run: |
+      - name: Package
+        run: |
           cd build/StandaloneOSX
           mv StandaloneOSX.app "Fusion Helper.app"
           zip -r FusionHelper_Mac.zip "Fusion Helper.app"
-      - uses: softprops/action-gh-release@v2
+      - name: Upload
+        uses: softprops/action-gh-release@v2
         with:
           files: build/StandaloneOSX/FusionHelper_Mac.zip
           fail_on_unmatched_files: true


### PR DESCRIPTION
Sorry to make another PR ^^'

This one's not super important, but I noticed some things that could be improved so this PR does that.

- Properly rename `StandaloneOSX.app` to `Fusion Helper.app`
- Include only `.app` and not `build/StandaloneOSX/` as well
- Add names to jobs in workflow
- Fail workflow if release asset isn't found or uploaded